### PR TITLE
Read asset-manifest.json from filesystem, rather than reading from URL

### DIFF
--- a/wp-graphiql.php
+++ b/wp-graphiql.php
@@ -60,7 +60,7 @@ class WPGraphiQL {
 	 * @return array|bool|string
 	 */
 	public function get_app_manifest() {
-		$manifest = file_get_contents( plugins_url( 'wp-graphiql/assets/app/build/asset-manifest.json' ) );
+		$manifest = file_get_contents( dirname( __FILE__ ) . '/assets/app/build/asset-manifest.json' );
 		$manifest = (array) json_decode( $manifest );
 		return $manifest;
 	}


### PR DESCRIPTION
Please see issue #5, "Asset manifest fails to load in Local By Flywheel with a self-signed cert."