### PR TITLE
Use site_url() to account for browser SSL

### DIFF
--- a/wp-graphiql.php
+++ b/wp-graphiql.php
@@ -121,7 +121,7 @@ class WPGraphiQL {
 				'wpGraphiQLSettings',
 				array(
 					'nonce' => wp_create_nonce( 'wp_rest' ),
-					'graphqlEndpoint' => trailingslashit( get_bloginfo( 'url' ) ) . 'index.php?' . \WPGraphQL\Router::$route,
+					'graphqlEndpoint' => trailingslashit( site_url() ) . 'index.php?' . \WPGraphQL\Router::$route,
 				)
 			);
 


### PR DESCRIPTION
Can you consider using `site_url()` instead of `get_bloginfo( 'url' )` when building the graphqlEndpoint.

`get_bloginfo( 'url' )` causes issues behind CloudFlare when using Flexible SSL, which requires the site to be set as HTTP in the WP settings, while forcing SSL elsewhere, such as Cloudflare rules.

This use case is not that uncommon and breaks this plugin (wp-graphiql tries to load over HTTP even if the protocol is HTTPS)

`site_url()` grabs the URL with the appropriate protocol by using `is_ssl()` under the hood.

reference: https://codex.wordpress.org/Function_Reference/site_url
