### PR TITLE
Ignore development files when creating an archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.* export-ignore
+/bin export-ignore
+/tests export-ignore
+/Gruntfile.js export-ignore
+/package.json export-ignore
+/phpcs.ruleset.xml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Ignore development files when creating an archive
See https://git-scm.com/docs/gitattributes#_creating_an_archive

@jasonbahl I'm unsure whether we should keep composer.json, package.json and Gruntfile.js, what do you think ? If we keep them we still won't produce a proper release archive, but those archive are supposed to be the full source code aswell. I'm confused by the usage we make of `gitattributes  export-ignore`.

Related to https://github.com/wp-graphql/wp-graphql/issues/1315